### PR TITLE
 #43 - fix: resolve issue with navigation to Notification page

### DIFF
--- a/client/src/features/activeNav/navSlice.js
+++ b/client/src/features/activeNav/navSlice.js
@@ -7,7 +7,7 @@ const navbarSlice = createSlice({
       active: "home",
     },
     sidebar: {
-      active: "Public profile",
+      active: "public profile",
     },
   },
   reducers: {

--- a/client/src/layouts/PrimaryHeader/ViewDesktop.jsx
+++ b/client/src/layouts/PrimaryHeader/ViewDesktop.jsx
@@ -4,15 +4,19 @@ import { useDispatch, useSelector } from "react-redux";
 import { Container, Col, Row } from "react-bootstrap";
 
 import ICONS from "../../assets/icons";
-import { COMMON_PATH } from "../../utils/constVariable";
 import IMAGES from "../../assets/images";
+import { COMMON_PATH } from "../../utils/constVariable";
 import useAxiosPrivate from "../../hooks/useAxiosPrivate";
 import { logOutReq } from "../../features/auth/apiRequest";
+import { formatCapitalize } from "../../utils/formatData";
 
 // Component
 import ShopLogo from "../../components/Logo/ShopLogo";
 import PrimaryNav from "./PrimaryNav";
-import { updateSelection } from "../../features/activeNav/navAction";
+import {
+  updateSelection,
+  updateSidebarSelection,
+} from "../../features/activeNav/navAction";
 
 //Style
 import classNames from "classnames/bind";
@@ -21,13 +25,25 @@ const cx = classNames.bind(styles);
 
 /* Sub nav component */
 const SubNav = () => {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const location = useLocation();
+
+  const currentPath = location.pathname;
+
   const user = useSelector((state) => state.auth.login.currentUser);
   const cart = useSelector((state) => state.cart.get.info);
   const hasUnreadNotification = useSelector(
     (state) => state.notification.hasUnread
   );
-  const navigate = useNavigate();
-  const dispatch = useDispatch();
+
+  const handleIconNavigateOnClick = (path, subNavActive, sidebarActive) => {
+    if (path !== currentPath) {
+      updateSelection(subNavActive, dispatch);
+      updateSidebarSelection(sidebarActive, dispatch);
+      navigate(path, { replace: true });
+    }
+  };
 
   return (
     <ul className={cx("sub-nav")}>
@@ -39,10 +55,13 @@ const SubNav = () => {
       <li className={cx("sub-nav__item")}>
         <div
           className={cx("sub-nav__link")}
-          onClick={() => {
-            updateSelection("notifications", dispatch);
-            navigate(COMMON_PATH.notification, { replace: true });
-          }}
+          onClick={() =>
+            handleIconNavigateOnClick(
+              COMMON_PATH.notification,
+              "notifications",
+              "news"
+            )
+          }
         >
           {ICONS.bellSlime}
           {hasUnreadNotification && <span className={cx("bell-dot")}></span>}
@@ -73,16 +92,22 @@ const SubNav = () => {
 const UserBarIsLogged = () => {
   const loggedOptions = [
     {
-      link: "/account/profile",
-      title: "Account Settings",
+      link: COMMON_PATH.account,
+      title: "account settings",
+      navbar: "account",
+      sidebar: "public profile",
     },
     {
       link: "/wishlist",
-      title: "My Wishlist",
+      title: "my wishlist",
+      navbar: "wishlist",
+      sidebar: "wishlist",
     },
     {
-      link: "/account/purchases",
-      title: "My Purchases",
+      link: COMMON_PATH.purchase,
+      title: "my purchases",
+      navbar: "purchase",
+      sidebar: "orders pending",
     },
   ];
   const user = useSelector((state) => state.auth.login.currentUser);
@@ -92,18 +117,19 @@ const UserBarIsLogged = () => {
   const location = useLocation();
   const axiosPrivate = useAxiosPrivate();
 
+  const currentPath = location.pathname;
+
   /* handle user action */
   const handleLogOut = async (e) => {
     e.preventDefault();
     await logOutReq(user.user_id, axiosPrivate, dispatch, navigate);
   };
 
-  const handleNavigateOnClick = (endpoint) => {
-    if (location.pathname.includes("account")) {
-      navigate(endpoint, { state: location, replace: true });
-    } else {
-      updateSelection("", dispatch);
-      navigate(endpoint, { replace: false });
+  const handleIconNavigateOnClick = (path, subNavActive, sidebarActive) => {
+    if (currentPath !== path) {
+      updateSelection(subNavActive, dispatch);
+      updateSidebarSelection(sidebarActive, dispatch);
+      navigate(path, { replace: true });
     }
   };
 
@@ -111,7 +137,13 @@ const UserBarIsLogged = () => {
     <>
       <div
         className={cx("sub-nav__link")}
-        onClick={() => handleNavigateOnClick("/account/profile")}
+        onClick={() =>
+          handleIconNavigateOnClick(
+            COMMON_PATH.account,
+            "account",
+            "public profile"
+          )
+        }
       >
         <img
           src={IMAGES.defaultAvatar}
@@ -125,9 +157,15 @@ const UserBarIsLogged = () => {
             <li key={idx} className={cx("user-options__option")}>
               <div
                 className={cx("user-options__link")}
-                onClick={() => handleNavigateOnClick(option.link)}
+                onClick={() =>
+                  handleIconNavigateOnClick(
+                    option.link,
+                    option.navbar,
+                    option.sidebar
+                  )
+                }
               >
-                {option.title}
+                {formatCapitalize(option.title)}
               </div>
             </li>
           );

--- a/client/src/pages/Notification/ViewDesktop/NotificationLayout.jsx
+++ b/client/src/pages/Notification/ViewDesktop/NotificationLayout.jsx
@@ -1,9 +1,6 @@
-import React, { useEffect, useRef } from "react";
-import { useSelector, useDispatch } from "react-redux";
+import React from "react";
+import { useSelector } from "react-redux";
 import { Container } from "react-bootstrap";
-
-import useAxiosPrivate from "../../../hooks/useAxiosPrivate";
-import { getNotificationsReq } from "../../../features/notification/notificationRequest";
 
 import SectionHeader from "../../../components/SectionHeader";
 import StateFilter from "./StateFilter";
@@ -12,27 +9,15 @@ import ErrorBlock from "../../../components/ErrorBlock";
 import NotificationList from "./NotificationList";
 import EmptyNotification from "./EmptyNotification";
 
-const NotificationLayout = ({ user }) => {
-  const isMounted = useRef(false);
-  const axiosPrivate = useAxiosPrivate();
-  const dispatch = useDispatch();
-
+const NotificationLayout = () => {
   const optionSelected = useSelector((state) => state.navbar.sidebar.active);
   const filter = useSelector((state) => state.notification.filter);
 
+  const isFetching = useSelector((state) => state.notification.get.isFetching);
+  const errorCause = useSelector((state) => state.notification.get.errorCause);
   const notifications = useSelector(
     (state) => state.notification.get.notifications
   );
-  const isFetching = useSelector((state) => state.notification.get.isFetching);
-  const errorCause = useSelector((state) => state.notification.get.errorCause);
-
-  useEffect(() => {
-    if (!isMounted.current) {
-      isMounted.current = true;
-      getNotificationsReq(user.user_id, axiosPrivate, dispatch);
-    }
-    // eslint-disable-next-line
-  }, []);
 
   const RenderListNotifications = ({ notifications, filter }) => {
     return notifications[filter].length === 0 ? (
@@ -45,15 +30,13 @@ const NotificationLayout = ({ user }) => {
   return (
     <Container style={{ position: "relative" }}>
       <SectionHeader title={optionSelected} />
-      <StateFilter /> {console.log(notifications)}
+      <StateFilter />
       {isFetching && !notifications ? (
         <LoadingSpinner />
       ) : errorCause ? (
         <ErrorBlock msg={errorCause} />
       ) : (
-        notifications &&
-        filter &&
-        optionSelected && (
+        notifications && (
           <RenderListNotifications
             notifications={notifications[optionSelected]}
             filter={filter}

--- a/client/src/pages/Notification/ViewDesktop/index.jsx
+++ b/client/src/pages/Notification/ViewDesktop/index.jsx
@@ -1,11 +1,6 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { Container, Row, Col } from "react-bootstrap";
-import { useSelector, useDispatch } from "react-redux";
-
-// custom hook, util func, ...
-import useAxiosPrivate from "../../../hooks/useAxiosPrivate";
-import { getUserReq } from "../../../features/user/userRequest";
-import { updateSidebarSelection } from "../../../features/activeNav/navAction";
+import { useSelector } from "react-redux";
 
 // Component Injected
 import Padding from "../../../components/Padding";
@@ -15,16 +10,6 @@ import NotificationLayout from "./NotificationLayout";
 
 const ViewDesktop = () => {
   const user = useSelector((state) => state.auth.login.currentUser);
-
-  const axiosPrivate = useAxiosPrivate();
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    getUserReq(user.user_id, axiosPrivate, dispatch);
-    updateSidebarSelection("news", dispatch);
-
-    // eslint-disable-next-line
-  }, []);
 
   return (
     <>
@@ -38,7 +23,7 @@ const ViewDesktop = () => {
           <Col lg="3" style={{ display: "flex", justifyContent: "center" }}>
             <Sidebar />
           </Col>
-          <Col lg="9">{user && <NotificationLayout user={user} />}</Col>
+          <Col lg="9">{user && <NotificationLayout />}</Col>
         </Row>
       </Container>
       <Padding />

--- a/client/src/pages/Notification/index.jsx
+++ b/client/src/pages/Notification/index.jsx
@@ -1,9 +1,6 @@
-import React, { useEffect, useRef } from "react";
-import { useDispatch } from "react-redux";
+import React, { useEffect } from "react";
 
 import useWindowDimension from "../../hooks/useWindowDimension";
-import { updateSidebarSelection } from "../../features/activeNav/navAction";
-import { setNotificationFilter } from "../../features/notification/notificationSlice";
 import { formatCapitalize } from "../../utils/formatData";
 
 import ViewDesktop from "./ViewDesktop";
@@ -15,18 +12,9 @@ const cx = classNames.bind(style);
 
 const Notification = () => {
   document.title = formatCapitalize("notifications");
-
-  const isMounted = useRef(false);
-  const dispatch = useDispatch();
   const { width } = useWindowDimension();
 
   useEffect(() => {
-    if (!isMounted.current) {
-      isMounted.current = true;
-      updateSidebarSelection("news", dispatch);
-      setNotificationFilter("all", dispatch);
-    }
-
     window.scrollTo(0, 0);
     // eslint-disable-next-line
   }, []);


### PR DESCRIPTION
The app was crashing when navigating to the Notification page. This was due to the 'option selected' variable being set by default "account profile" the first time the user login to the website. So that notifications["account profile"] is undefined. What we expected is notifications["news"].

I added a statement to update the sidebar selection to "news" before navigating to the notifications page and tested the app to confirm that the issue is now resolved.

Fixes #43