### PR TITLE
 #50 - fix: disabled react, redux devtools on production.

### DIFF
--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -4,6 +4,10 @@ import App from "./App";
 import GlobalStyle from "./components/GlobalStyle/GlobalStyle";
 import AuthProvider from "./context/AuthProvider";
 
+import { disableReactDevTools } from "./utils/disableReactDevtools";
+
+if (process.env.NODE_ENV === "production") disableReactDevTools();
+
 const root = ReactDOM.createRoot(document.getElementById("root"));
 
 root.render(

--- a/admin/src/redux/store.js
+++ b/admin/src/redux/store.js
@@ -15,6 +15,7 @@ const store = configureStore({
         ignoredActionPaths: ["payload.headers"],
       },
     }),
+  devTools: process.env.NODE_ENV === "production" ? false : true,
 });
 
 export default store;

--- a/admin/src/utils/disableReactDevtools.js
+++ b/admin/src/utils/disableReactDevtools.js
@@ -1,0 +1,36 @@
+const isFunction = (obj) => {
+  return typeof obj === "function";
+};
+
+const isObject = (obj) => {
+  const type = typeof obj;
+
+  return type === "function" || (type === "object" && !!obj);
+};
+
+const hasWindowObject = () => {
+  return typeof window !== "undefined" && window.document;
+};
+
+export const disableReactDevTools = () => {
+  if (hasWindowObject()) {
+    // Ensure the React Developer Tools global hook exists
+    if (!isObject(window.__REACT_DEVTOOLS_GLOBAL_HOOK__)) {
+      return;
+    }
+
+    // Replace all global hook properties with a no-op function or a null value
+    for (const prop in window.__REACT_DEVTOOLS_GLOBAL_HOOK__) {
+      if (prop === "renderers") {
+        // prevents console error when dev tools try to iterate of renderers
+        window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop] = new Map();
+        continue;
+      }
+      window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop] = isFunction(
+        window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop]
+      )
+        ? Function.prototype
+        : null;
+    }
+  }
+};

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,0 +1,24 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.env
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/client/src/features/store.js
+++ b/client/src/features/store.js
@@ -23,4 +23,5 @@ export default configureStore({
         ignoredActionPaths: ["payload.headers"],
       },
     }),
+  devTools: process.env.NODE_ENV === "production" ? false : true,
 });

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -3,8 +3,12 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import GlobalStyle from "./components/GlobalStyle/GlobalStyle";
 import AuthProvider from "./context/AuthProvider";
+import { disableReactDevTools } from "./utils/disableReactDevtools";
+
+if (process.env.NODE_ENV === "production") disableReactDevTools();
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
+
 root.render(
   <React.StrictMode>
     <AuthProvider>

--- a/client/src/utils/disableReactDevtools.js
+++ b/client/src/utils/disableReactDevtools.js
@@ -1,0 +1,36 @@
+const isFunction = (obj) => {
+  return typeof obj === "function";
+};
+
+const isObject = (obj) => {
+  const type = typeof obj;
+
+  return type === "function" || (type === "object" && !!obj);
+};
+
+const hasWindowObject = () => {
+  return typeof window !== "undefined" && window.document;
+};
+
+export const disableReactDevTools = () => {
+  if (hasWindowObject()) {
+    // Ensure the React Developer Tools global hook exists
+    if (!isObject(window.__REACT_DEVTOOLS_GLOBAL_HOOK__)) {
+      return;
+    }
+
+    // Replace all global hook properties with a no-op function or a null value
+    for (const prop in window.__REACT_DEVTOOLS_GLOBAL_HOOK__) {
+      if (prop === "renderers") {
+        // prevents console error when dev tools try to iterate of renderers
+        window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop] = new Map();
+        continue;
+      }
+      window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop] = isFunction(
+        window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop]
+      )
+        ? Function.prototype
+        : null;
+    }
+  }
+};


### PR DESCRIPTION
This commit adds new module disableReactDevtools and sets "devtools" on the redux store to false to disable them in the production environment.

Fixed #50

closes #50 